### PR TITLE
Boyscout/rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "cross-env": "^7.0.3",
         "dotenv": "^16.0.3",
         "express": "4.18.2",
+        "express-rate-limit": "^6.7.0",
         "express-validator": "^7.0.1",
         "js-cookie": "^3.0.5",
         "jsonwebtoken": "^9.0.0",
@@ -3415,6 +3416,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express-validator": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.0.3",
     "express": "4.18.2",
+    "express-rate-limit": "^6.7.0",
     "express-validator": "^7.0.1",
     "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.0",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -57,6 +57,7 @@ The server handles the following environment variables:
 
 You also need to set up your own environment variable. To do this you have to copy the template, which you can find [here](.env.example).
 Rename the copy to `.env` and fill in the variables
+
 ### Sequelize
 
 Assuming you've followed the instructions in the [README in the root](../../README.md#developing) of the repository on

--- a/packages/server/src/app/app.js
+++ b/packages/server/src/app/app.js
@@ -1,12 +1,22 @@
 const dotenv = require('dotenv')
-const express = require('express')
-const usersRouter = require('./models/user/user.router')
-const authRouter = require('./models/auth/auth.router')
-const ErrorHandlerService = require('./services/error-handler.service')
-const corsMiddleware = require('./middleware/cors-middleware')
 const cookieParser = require('cookie-parser')
+const express = require('express')
+const rateLimit = require('express-rate-limit')
 const path = require('path')
+const corsMiddleware = require('./middleware/cors-middleware')
+const authRouter = require('./models/auth/auth.router')
+const usersRouter = require('./models/user/user.router')
+const ErrorHandlerService = require('./services/error-handler.service')
+
 const app = express()
+
+// On all routes, allow maximum 50 requests per minute
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 50,
+  standardHeaders: true,
+  legacyHeaders: false
+})
 
 // Load environment variables from a different directory
 const envPath = path.join(__dirname, 'config', '../../../.env')
@@ -18,6 +28,7 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(corsMiddleware)
 app.use(cookieParser())
+app.use(limiter)
 
 app.use('/api/user', usersRouter)
 app.use('/api/auth', authRouter)


### PR DESCRIPTION
* Add a rate limiter for limiting the amount of requests a consumer of our api can make within a set window
* add a specific rate limiter with a smaller window for the authentication routes of our api