### PR TITLE
Fix for main js not found

### DIFF
--- a/packages/client/src/index.html
+++ b/packages/client/src/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wasted</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <script type="module" src="main.js"></script>
+    <script type="module" src="./main.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Fixed main.js not found when url has more then one directory ( e.g. /challenge/:id) or when adding route params
