### PR TITLE
Make sure the docker client container handles broswer refresh correctly

### DIFF
--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -21,6 +21,8 @@ FROM nginx:1.24-alpine
 
 COPY --from=builder /client-app/dist/client /usr/share/nginx/html
 
+COPY packages/client/default.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80/tcp
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/packages/client/default.conf
+++ b/packages/client/default.conf
@@ -1,0 +1,48 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+
+        index  index.html index.htm;
+        
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
When refreshing/reloading the browser, make sure that NGINX (which is the final Docker layer on which the client runs in) lets Vue handle the routing and redirects 404 routing errors to the index.html so that Vue can take care of the routing instead of NGINX